### PR TITLE
Auto-completion feature for bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,25 @@ Before building and running the project, ensure that you have the following prer
 * Build the project using Gradle:
 
 ```bash
-  gradle build
+  ./gradlew build
 ```
 This command compiles the source code, runs tests, and generates the executable JAR file.
 
 ### Running the CLI Tool
 
-Once you have built the project, you can run the CLI tool using the following command:
+You can run the CLI tool using Gradle's run task.
+```bash
+    ./gradlew run --args='[command] [options]'
+```
+
+For example,
+```bash
+    ./gradlew run --args='fetchTxIds -s 730000'
+```
+
+### Alternate Method to Run
+
+You can run the CLI tool using the following command:
 
 ```bash
   java -jar build/libs/your-project.jar [command] [options]
@@ -60,27 +72,26 @@ For example,
     java -jar build/libs/your-project.jar fetchBlockId -s 730000
 ```
 
-### Alternate Method to Run
-
-You can run the CLI tool using Gradle's run task.
-```bash
-    ./gradlew run --args='[command] [options]'
-```
-
-For example,
-```bash
-    ./gradlew run --args='fetchTxIds -s 730000'
-```
-
-### Running tests
-To execute the project tests, use the following command:
-
-```bash
-    gradle test
-```
-
 That's it! You should now be able to build the project and run the CLI tool with the specified commands and options.
 
+### Guide for adding auto-completion:
+
+- Run the command 
+`./gradlew installDist`
+- The above command will create script in the build/install directory, and we can use them to run the application like a command line tool.
+- Source the script correctly in the .bashrc file by adding the following line
+`source /your/path/to/kotlin-cli-completion.sh`
+- In my case for example, the line looks like:
+`source /home/claddy/Documents/Projects/MempoolCLI/kotlin-cli-completion.sh`
+- Now, set an Alias, by adding the following line
+`alias kotlin-cli="/path/to/your/build/install/mac/bin/your-application-name" `
+- On my case for example, the line looks like,
+`alias kotlin-cli="/home/claddy/Documents/Projects/MempoolCLI/build/install/mac/bin/mac" `
+- Finally, source the file 
+`source ~/.bashrc`
+- Now run the command 
+ `kotlin-cli fetchBlockId -s 730000`
+- Use `Tab` button to play around the auto completion.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -80,17 +80,17 @@ That's it! You should now be able to build the project and run the CLI tool with
 `./gradlew installDist`
 - The above command will create script in the build/install directory, and we can use them to run the application like a command line tool.
 - Source the script correctly in the .bashrc file by adding the following line
-`source /your/path/to/kotlin-cli-completion.sh`
+`source /your/path/to/mempool-cli.bash-completion`
 - In my case for example, the line looks like:
-`source /home/claddy/Documents/Projects/MempoolCLI/kotlin-cli-completion.sh`
+`source /home/claddy/Documents/Projects/MempoolCLI/contrib/mempool-cli.bash-completion`
 - Now, set an Alias, by adding the following line
 `alias kotlin-cli="/path/to/your/build/install/mac/bin/your-application-name" `
 - On my case for example, the line looks like,
-`alias kotlin-cli="/home/claddy/Documents/Projects/MempoolCLI/build/install/mac/bin/mac" `
+`alias mempool-cli="/home/claddy/Documents/Projects/MempoolCLI/build/install/mac/bin/mac" `
 - Finally, source the file 
 `source ~/.bashrc`
 - Now run the command 
- `kotlin-cli fetchBlockId -s 730000`
+ `mempool-cli fetchBlockId -s 730000`
 - Use `Tab` button to play around the auto completion.
 
 ## Support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,3 +35,11 @@ kotlin {
 application {
     mainClass.set("MainKt")
 }
+
+tasks.jar {
+    manifest {
+        attributes["Main-Class"] = "MainKt"
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+}

--- a/contrib/mempool-cli.bash-completion
+++ b/contrib/mempool-cli.bash-completion
@@ -1,4 +1,7 @@
 # mempool-cli.bash-completion
+# Tutorials used:
+# https://askubuntu.com/questions/68175/how-to-create-script-with-auto-complete
+# https://iridakos.com/programming/2018/03/01/bash-programmable-completion-tutorial
 
 _mempool_cli_completion() {
     local cur prev opts subopts

--- a/contrib/mempool-cli.bash-completion
+++ b/contrib/mempool-cli.bash-completion
@@ -1,6 +1,6 @@
-# kotlin-cli-completion.sh
+# mempool-cli.bash-completion
 
-_kotlin_cli_completion() {
+_mempool_cli_completion() {
     local cur prev opts subopts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -32,5 +32,4 @@ _kotlin_cli_completion() {
     return 0
 }
 
-complete -F _kotlin_cli_completion kotlin-cli
-
+complete -F _mempool_cli_completion mempool-cli

--- a/kotlin-cli-completion.sh
+++ b/kotlin-cli-completion.sh
@@ -1,0 +1,36 @@
+# kotlin-cli-completion.sh
+
+_kotlin_cli_completion() {
+    local cur prev opts subopts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="fetchBlockId fetchTxIds"
+
+    if [[ ${cur} == -* ]]; then
+        subopts="-s"
+        COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+        return 0
+    fi
+
+    case "${prev}" in
+        fetchBlockId)
+            subopts="-s"
+            COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+            return 0
+            ;;
+        fetchTxIds)
+            subopts="-s"
+            COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+            ;;
+    esac
+
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+}
+
+complete -F _kotlin_cli_completion kotlin-cli
+

--- a/src/test/kotlin/FetchBlockIdFailing.kt
+++ b/src/test/kotlin/FetchBlockIdFailing.kt
@@ -1,6 +1,4 @@
-
-import kotlinx.cli.ArgParser
-import kotlinx.cli.ExperimentalCli
+import kotlinx.cli.*
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/FetchBlockIdFailing.kt
+++ b/src/test/kotlin/FetchBlockIdFailing.kt
@@ -1,19 +1,24 @@
-import kotlinx.cli.*
+
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCli::class)
 class FetchBlockIdCommandFailingTest {
 
     @Test
-    fun `test execute fetchBlockIdCommand with failing client`() {
+    fun `test execute fetchBlockIdCommand with failing client`() = runBlocking {
         val resultWriter = DummyResultWriter()
         val failingClient = FailingMempoolClient(RuntimeException("Mocked failure"))
+
         val command = FetchBlockIdCommand(resultWriter, failingClient)
         val parser = ArgParser("test")
         parser.subcommands(command)
         parser.parse(arrayOf("fetchBlockId", "-s", "730000"))
-
-        assertNotNull(resultWriter.lastError, "Mocked failure")
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertEquals("Error fetching block ID: Mocked failure", resultWriter.lastError)
     }
 }

--- a/src/test/kotlin/FetchTxIdsFailingTest.kt
+++ b/src/test/kotlin/FetchTxIdsFailingTest.kt
@@ -1,6 +1,4 @@
-
-import kotlinx.cli.ArgParser
-import kotlinx.cli.ExperimentalCli
+import kotlinx.cli.*
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/src/test/kotlin/FetchTxIdsFailingTest.kt
+++ b/src/test/kotlin/FetchTxIdsFailingTest.kt
@@ -1,19 +1,25 @@
-import kotlinx.cli.*
+
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCli::class)
 class FetchTxIdsCommandFailingTest {
 
     @Test
-    fun `test execute fetchTxIdsCommand with failing client`() {
+    fun `test execute fetchBlockIdCommand with failing client`() = runBlocking {
         val resultWriter = DummyResultWriter()
         val failingClient = FailingMempoolClient(RuntimeException("Mocked failure"))
-        val command = FetchTxIdsCommand(resultWriter, failingClient)
+
+        val command = FetchBlockIdCommand(resultWriter, failingClient)
         val parser = ArgParser("test")
         parser.subcommands(command)
-        parser.parse(arrayOf("fetchTxIds", "-s", "730000"))
-
-        assertNotNull(resultWriter.lastError, "An error should have been written")
+        parser.parse(arrayOf("fetchBlockId", "-s", "730000"))
+        Assertions.assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        Assertions.assertEquals("Error fetching block ID: Mocked failure", resultWriter.lastError)
     }
 }

--- a/src/test/kotlin/MempoolClientMocks.kt
+++ b/src/test/kotlin/MempoolClientMocks.kt
@@ -11,6 +11,6 @@ class DummyMempoolClient : IMempoolClient {
 }
 
 class FailingMempoolClient(private val failure: Throwable) : IMempoolClient {
-    override suspend fun fetchFirstBlockId(startHeight: Int): Result<String> = throw failure
-    override suspend fun fetchTransactionIds(blockId: String): Result<List<String>> = throw failure
+    override suspend fun fetchFirstBlockId(startHeight: Int): Result<String> = Result.failure(failure)
+    override suspend fun fetchTransactionIds(blockId: String): Result<List<String>> = Result.failure(failure)
 }


### PR DESCRIPTION
### Guide for adding auto-completion:

- Run the command 
`./gradlew installDist`
- The above command will create script in the build/install directory, and we can use them to run the application like a command line tool.
- Source the script correctly in the .bashrc file by adding the following line
`source /your/path/to/kotlin-cli-completion.sh`
- In my case for example, the line looks like:
`source /home/claddy/Documents/Projects/MempoolCLI/kotlin-cli-completion.sh`
- Now, set an Alias, by adding the following line
`alias kotlin-cli="/path/to/your/build/install/mac/bin/your-application-name" `
- On my case for example, the line looks like,
`alias kotlin-cli="/home/claddy/Documents/Projects/MempoolCLI/build/install/mac/bin/mac" `
- Finally, source the file 
`source ~/.bashrc`
- Now run the command 
 `kotlin-cli fetchBlockId -s 730000`
- Use `Tab` button to play around the auto completion.